### PR TITLE
Missing ';' at the end of lines

### DIFF
--- a/addons/goko_BI/cfgFunctions.hpp
+++ b/addons/goko_BI/cfgFunctions.hpp
@@ -9,36 +9,36 @@ class CfgFunctions
 	class goko
 	{
 		class ballisticImpact
-		{	
+		{
 			class BallisticImpactMain
 			{
 				file = "goko_BI\functions\fn_gokoBI_main.sqf";
-				preInit = 1
+				preInit = 1;
 			};
 			class particlefxBlood
 			{
 				file = "goko_BI\functions\fn_particleEffectsBlood.sqf";
-				preInit = 1
+				preInit = 1;
 			};
 			class particlefxHeadgear
 			{
 				file = "goko_BI\functions\fn_particleEffectsHeadgear.sqf";
-				preInit = 1
+				preInit = 1;
 			};
 			class particlefxHMD
 			{
 				file = "goko_BI\functions\fn_particleEffectsHMD.sqf";
-				preInit = 1
+				preInit = 1;
 			};
 			class particlefxOther
 			{
 				file = "goko_BI\functions\fn_particleEffectsOther.sqf";
-				preInit = 1
+				preInit = 1;
 			};
 			class gokobi_optionalcba
 			{
 				file = "goko_BI\functions\gokobi_options.sqf";
-				preInit = 1
+				preInit = 1;
 			};
 		};
 	};


### PR DESCRIPTION
Fixes rpt errors.
```
16:15:17 File goko_BI\cfgFunctions.hpp, line 9: '/CfgFunctions/goko/ballisticImpact/BallisticImpactMain.preInit': Missing ';' at the end of line
16:15:17 File goko_BI\cfgFunctions.hpp, line 14: '/CfgFunctions/goko/ballisticImpact/particlefxBlood.preInit': Missing ';' at the end of line
16:15:17 File goko_BI\cfgFunctions.hpp, line 19: '/CfgFunctions/goko/ballisticImpact/particlefxHeadgear.preInit': Missing ';' at the end of line
16:15:17 File goko_BI\cfgFunctions.hpp, line 24: '/CfgFunctions/goko/ballisticImpact/particlefxHMD.preInit': Missing ';' at the end of line
16:15:17 File goko_BI\cfgFunctions.hpp, line 29: '/CfgFunctions/goko/ballisticImpact/particlefxOther.preInit': Missing ';' at the end of line
16:15:17 File goko_BI\cfgFunctions.hpp, line 34: '/CfgFunctions/goko/ballisticImpact/gokobi_optionalcba.preInit': Missing ';' at the end of line
```